### PR TITLE
FOLIO-1609

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <vertx-version>3.5.1</vertx-version>
+    <vertx-version>3.5.4</vertx-version>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -357,6 +357,19 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.1</version>
+        <configuration>
+          <!-- TODO: update to version 3.0.0 and remove useSystemClassLoader
+               https://issues.folio.org/browse/FOLIO-1609
+               https://issues.apache.org/jira/browse/SUREFIRE-1588
+          -->
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
+
 
     </plugins>
   </build>


### PR DESCRIPTION
- workaround for https://issues.apache.org/jira/browse/SUREFIRE-1588
- update vertx 3.5.4