### PR TITLE
MODTAG-52 Fix pgcrypto schema extension creation

### DIFF
--- a/src/main/resources/db/changelog/changes/v1.0.0/create-tags-table.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.0/create-tags-table.xml
@@ -8,7 +8,7 @@
 
     <changeSet id="MODTAG-52@@create-pgcrypto-extension" author="psmagin">
         <sql dbms="postgresql">
-            CREATE EXTENSION IF NOT EXISTS pgcrypto;
+            CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA public;
         </sql>
     </changeSet>
 


### PR DESCRIPTION
## Purpose
Fix pgcrypto schema extension creation. Before this update script created an extension in mod_tags schema and other modules couldn't use it 