### PR TITLE
mod-tags: Handle exception and change API documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.4.RELEASE</version>
+    <version>2.5.2</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>

--- a/src/main/java/org/folio/tags/controller/ErrorHandlingAdvice.java
+++ b/src/main/java/org/folio/tags/controller/ErrorHandlingAdvice.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -52,7 +53,8 @@ public class ErrorHandlingAdvice {
     MissingServletRequestParameterException.class,
     CqlQueryValidationException.class,
     MethodArgumentTypeMismatchException.class,
-    HttpMessageNotReadableException.class
+    HttpMessageNotReadableException.class,
+    MethodArgumentNotValidException.class
   })
   public Errors handleMissingParameterException(Exception e) {
     return createInternalError(e.getLocalizedMessage(), VALIDATION_ERROR);

--- a/src/main/resources/swagger.api/tags.yml
+++ b/src/main/resources/swagger.api/tags.yml
@@ -36,8 +36,6 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/TagCollection'
-        '400':
-          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '422':
@@ -52,8 +50,6 @@ paths:
       responses:
         '201':
           $ref: '#/components/responses/Tag'
-        '400':
-          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '422':
@@ -95,8 +91,6 @@ paths:
       responses:
         '204':
           description: Tag deleted successfully
-        '400':
-          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -136,11 +130,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/tagDtoCollection'
-    BadRequest:
-      description: Bad request, e.g. malformed request body or query parameter.
-      content:
-        text/plain:
-          example: malformed parameter 'query', syntax error at column 6
     Unauthorized:
       description: Not authorized to perform requested action
       content:


### PR DESCRIPTION
###  **Purpose**
Not valid data cause 500 error, instead of 422.

API documentation declares 400 error if malformed request body or parameter 'query' - but in this case must be 422 error.

###  **Learning**
https://issues.folio.org/browse/MODTAG-55