### PR TITLE
FAT-935: Spring-base rollback to 1.2

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -56,21 +56,18 @@
     },
     {
       "id": "_tenant",
-      "version": "2.0",
+      "version": "1.2",
       "interfaceType": "system",
       "handlers": [
         {
-          "methods": [
-            "POST"
-          ],
-          "pathPattern": "/_/tenant"
+          "methods": ["POST"],
+          "pathPattern": "/_/tenant",
+          "permissionsRequired": []
         },
         {
-          "methods": [
-            "GET",
-            "DELETE"
-          ],
-          "pathPattern": "/_/tenant/{id}"
+          "methods": ["DELETE"],
+          "pathPattern": "/_/tenant",
+          "permissionsRequired": []
         }
       ]
     }


### PR DESCRIPTION
### Purpose
Since the removal of the tenant is not yet implemented in `2.0`
It is better to moving to version `1.2`

### Learn
[FAT-935](https://issues.folio.org/browse/FAT-935)