### PR TITLE
MODTAG-79 Fix delete tenant not supported error

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -56,7 +56,7 @@
     },
     {
       "id": "_tenant",
-      "version": "1.2",
+      "version": "2.0",
       "interfaceType": "system",
       "handlers": [
         {
@@ -65,8 +65,8 @@
           "permissionsRequired": []
         },
         {
-          "methods": ["DELETE"],
-          "pathPattern": "/_/tenant",
+          "methods": ["GET", "DELETE"],
+          "pathPattern": "/_/tenant/{id}",
           "permissionsRequired": []
         }
       ]


### PR DESCRIPTION
### Purpose
Fix delete tenant not supported error

### Approach
* update module descriptor with supported `TenantAPI version 