### PR TITLE
MODTAG-85 Update folio-spring-base to v4.1.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 1.2.0-SNAPSHOT 2022-xx-xx
+* MODTAG-66 Update folio-spring-base to v4.1.0
+
 ## 1.1.0 2022-02-23
 * MODTAG-66 Update folio-spring-base to v3.0
 * MODTAG-70 Improve pom.xml

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## 1.2.0-SNAPSHOT 2022-xx-xx
-* MODTAG-66 Update folio-spring-base to v4.1.0
+* MODTAG-85 Update folio-spring-base to v4.1.0
 
 ## 1.1.0 2022-02-23
 * MODTAG-66 Update folio-spring-base to v3.0

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.3</version>
+    <version>2.7.0</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -24,20 +24,20 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <folio-spring-base.version>3.0.1</folio-spring-base.version>
-    <mapstruct.version>1.4.2.Final</mapstruct.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <folio-spring-base.version>4.1.0</folio-spring-base.version>
+    <mapstruct.version>1.5.1.Final</mapstruct.version>
+    <log4j2.version>2.17.2</log4j2.version>
 
     <!-- Test properties -->
-    <testcontainers.version>1.16.3</testcontainers.version>
+    <testcontainers.version>1.17.2</testcontainers.version>
 
     <!-- Plugin properties-->
     <openapi.input.file>${project.basedir}/src/main/resources/swagger.api/tags.yml</openapi.input.file>
-    <openapi-generator.version>5.3.1</openapi-generator.version>
+    <openapi-generator.version>5.4.0</openapi-generator.version>
     <lombok.mapstruct-binding.version>0.2.0</lombok.mapstruct-binding.version>
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
     <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
-    <maven-release-plugin.version>3.0.0-M4</maven-release-plugin.version>
+    <maven-release-plugin.version>3.0.0-M6</maven-release-plugin.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### Purpose
Update folio-spring-base to v4.1.0

### Approach
- Update folio-spring-base to v4.1.0
- Update dependencies 

### Learning
[MODTAG-85](https://issues.folio.org/browse/MODTAG-85)
