### PR TITLE
MODTAG-95 Update folio-spring-base to v5.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## 1.3.0 xxxx-xx-xx
+* FOLIO-3527 Update PR template
+* MODTAG-94 Add checkstyle maven plugin
+* MODTAG-95 Update folio-spring-base to v5.0.0
+
 ## 1.2.0 2022-06-27
 * MODTAG-85 Update folio-spring-base to v4.1.0
 * MODTAG-79 Support tenant deletion

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.4</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -24,21 +24,21 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <folio-spring-base.version>4.1.0</folio-spring-base.version>
-    <mapstruct.version>1.5.1.Final</mapstruct.version>
+    <folio-spring-base.version>5.0.0</folio-spring-base.version>
+    <mapstruct.version>1.5.2.Final</mapstruct.version>
     <log4j2.version>2.17.2</log4j2.version>
 
     <!-- Test properties -->
-    <testcontainers.version>1.17.2</testcontainers.version>
+    <testcontainers.version>1.17.4</testcontainers.version>
 
     <!-- Plugin properties-->
     <openapi.input.file>${project.basedir}/src/main/resources/swagger.api/tags.yml</openapi.input.file>
-    <openapi-generator.version>5.4.0</openapi-generator.version>
+    <openapi-generator.version>6.2.0</openapi-generator.version>
     <lombok.mapstruct-binding.version>0.2.0</lombok.mapstruct-binding.version>
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
     <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
     <maven-release-plugin.version>3.0.0-M6</maven-release-plugin.version>
-    <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
+    <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Purpose
Update folio-spring-base to v5.0.0

## Approach
- update parent and dependencies

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed

### Learning
[MODTAG-95](https://issues.folio.org/browse/MODTAG-95)
