### PR TITLE
MODTAG-105: Can't find tag with special character

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <folio-spring-base.version>6.0.1</folio-spring-base.version>
+    <folio-spring-base.version>6.0.2</folio-spring-base.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
 
     <!-- Test properties -->


### PR DESCRIPTION
https://issues.folio.org/browse/MODTAG-105

Approach: Upgrade to folio-spring-base 6.0.2 with the fix:

https://issues.folio.org/browse/FOLSPRINGB-94
"Broken queryByLike masking, SQL injection"