### PR TITLE
MODTAG-113: Migrate to folio-spring-support v7.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+## v2.1.0 in progress
+### Dependencies
+* Bump `folio-spring-base` from `6.0.2` to `7.0.0`
+* Add  `folio-spring-cql` with groupId `org.folio` & version `7.0.0`
+
+### Tech Dept
+* Migrate to folio-spring-support v7.0.0 ([MODTAG-113](https://issues.folio.org/browse/MODTAG-113))
+
 ## v2.0.1 2023-03-09
 ### Tech Dept
 * OpenSSL 3.0.8 fixing 8 vulnerabilities ([MODTAG-106](https://issues.folio.org/browse/MODTAG-106))

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <folio-spring-base.version>6.0.2</folio-spring-base.version>
+    <folio-spring-base.version>7.0.0</folio-spring-base.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
 
     <!-- Test properties -->
@@ -45,6 +45,11 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-base</artifactId>
+      <version>${folio-spring-base.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-spring-cql</artifactId>
       <version>${folio-spring-base.version}</version>
     </dependency>
     <dependency>

--- a/src/main/java/org/folio/tags/service/TagServiceImpl.java
+++ b/src/main/java/org/folio/tags/service/TagServiceImpl.java
@@ -26,7 +26,7 @@ public class TagServiceImpl implements TagService {
   public TagDtoCollection fetchTagCollection(String query, Integer offset, Integer limit) {
     log.debug("fetchTagCollection:: trying to fetch tag collection by query: {}, offset: {}, limit: {}",
              query, offset, limit);
-    Page<Tag> tagPage = repository.findByCQL(query, OffsetRequest.of(offset, limit));
+    Page<Tag> tagPage = repository.findByCql(query, OffsetRequest.of(offset, limit));
     log.info("fetchTagCollection:: loaded tags: {}", tagPage.getNumberOfElements());
     return mapper.toDtoCollection(tagPage);
   }


### PR DESCRIPTION
## Purpose
_Migrate to folio-spring-support v7.0.0_

## Approach
_Increased version of folio-spring-base version from 6.0.2 to 7.0.0_
_Added dependecy folio-spring-cql v.7.0.0  &&  updated NEWS_
_Changed method from findByCQL to findByCql_

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [x] Interface versions changes
- [x] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.