### PR TITLE
MODTAG-133: ignore incoming tag id during creation

### DIFF
--- a/src/main/java/org/folio/tags/mapper/TagsMapper.java
+++ b/src/main/java/org/folio/tags/mapper/TagsMapper.java
@@ -24,7 +24,8 @@ public interface TagsMapper {
   TagDto toDto(Tag entity);
 
   @InheritInverseConfiguration
-  Tag toEntity(TagDto dto);
+  @Mapping(target = "id", ignore = true)
+  Tag toNewEntity(TagDto dto);
 
   default TagDtoCollection toDtoCollection(Page<Tag> entityList) {
     return new TagDtoCollection().tags(toDtoList(entityList.getContent())).totalRecords(

--- a/src/main/java/org/folio/tags/service/TagServiceImpl.java
+++ b/src/main/java/org/folio/tags/service/TagServiceImpl.java
@@ -34,7 +34,7 @@ public class TagServiceImpl implements TagService {
   @Override
   public TagDto createTag(TagDto tag) {
     log.debug("createTag:: trying to create a tag with: {}", tag);
-    Tag saved = repository.save(mapper.toEntity(tag));
+    Tag saved = repository.save(mapper.toNewEntity(tag));
     log.info("createTag:: created a tag: {}", saved);
     return mapper.toDto(saved);
   }

--- a/src/test/java/org/folio/tags/controller/TagsApiTest.java
+++ b/src/test/java/org/folio/tags/controller/TagsApiTest.java
@@ -158,12 +158,13 @@ class TagsApiTest extends ApiTest {
   void createNewTag() throws Exception {
     var label = "First tag";
     var description = "This is the first test tag";
-    var tag = new TagDto().label(label).description(description);
+    var tag = new TagDto().label(label).description(description).id(UUID.randomUUID().toString());
     mockMvc.perform(postTag(tag))
       .andExpect(status().isCreated())
       .andExpect(header().string(HttpHeaders.LOCATION, matchesRegex(TAGS_LOCATION_PATTERN)))
       .andExpect(labelMatch("$", is(label)))
       .andExpect(descriptionMatch("$", is(description)))
+      .andExpect(jsonPath("$.id").isNotEmpty())
       .andExpect(jsonPath("$.metadata.createdByUserId").value(USER_ID))
       .andExpect(jsonPath("$.metadata.createdDate").isNotEmpty());
   }


### PR DESCRIPTION
## Purpose
Fix MODTAG-133

## Approach
Ignore incoming TagDTO id, which causes the issue, because Tag entity ID is a generated value.

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

